### PR TITLE
use strings to avoid a lot of type conversion

### DIFF
--- a/wildmatch.go
+++ b/wildmatch.go
@@ -106,3 +106,22 @@ func (w Wildcard) IsSubsetOfAny(supersets ...Wildcard) (result Wildcard, found b
 	}
 	return
 }
+
+// IsSubsetOfAny verifies if current wildcard `w` is a subset of any of the given sets.
+// Wildcard A is subset of B if any possible path that matches A also matches B.
+// If multiple subsets match then the smallest or first lexicographical set is returned
+func IsSubsetOfAny(w string, sets ...string) (result string, found bool) {
+	for _, superset := range sets {
+		if !IsSubsetOf(w, superset) {
+			continue
+		}
+		found = true
+		if result == "" || IsSubsetOf(superset, result) {
+			result = superset
+		}
+	}
+	return
+}
+
+// NOTE it's hard to combine both IsSubsetOfAny() functions to one
+// because of missing []string <-> []Wildcard conversion

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -111,13 +111,25 @@ func (w Wildcard) IsSubsetOfAny(supersets ...Wildcard) (result Wildcard, found b
 // Wildcard A is subset of B if any possible path that matches A also matches B.
 // If multiple subsets match then the smallest or first lexicographical set is returned
 func IsSubsetOfAny(w string, sets ...string) (result string, found bool) {
-	for _, superset := range sets {
+	if index := IsSubsetOfAnyI(w, sets...); index >= 0 {
+		return sets[index], true
+	}
+
+	return "", false // not found
+}
+
+// IsSubsetOfAny verifies if current wildcard `w` is a subset of any of the given sets.
+// Wildcard A is subset of B if any possible path that matches A also matches B.
+// If multiple subsets match then the smallest or first lexicographical set is returned
+// Return -1 if not found or superset index.
+func IsSubsetOfAnyI(w string, sets ...string) (found int) {
+	found = -1 // not found by default
+	for i, superset := range sets {
 		if !IsSubsetOf(w, superset) {
 			continue
 		}
-		found = true
-		if result == "" || IsSubsetOf(superset, result) {
-			result = superset
+		if found < 0 || IsSubsetOf(superset, sets[found]) {
+			found = i
 		}
 	}
 	return

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -9,74 +9,84 @@ import (
 // It is an alias to the string type to provide extra methods of this package.
 type Wildcard string
 
-// IsSubset verifies if current wildcard is a subset of a given one.
+// IsSubset verifies if current wildcard is a subset of a given one `superset`.
 // Wildcard A is subset of B if any possible path that matches A also matches B.
-func (w Wildcard) IsSubset(set Wildcard) bool {
-	return IsSubset(string(w), string(set))
+func (w Wildcard) IsSubset(superset Wildcard) bool {
+	return IsSubset(string(w), string(superset))
 }
 
-// IsSubset verifies if `w` wildcard is a subset of `set`.
-func IsSubset(w string, set string) bool {
+// Contains verifies if current wildcard is a superset of a given one `subset`.
+// This operation is inversion of IsSubset().
+func (w Wildcard) Contains(subset Wildcard) bool {
+	return IsSubset(string(subset), string(w))
+}
+
+// IsSubset verifies if `w` wildcard is a subset of `s`.
+// I.e. checks if `s` is a superset of subset `w`.
+func IsSubset(w string, s string) bool {
 
 	// shortcut for identical sets
-	if set == w {
+	if s == w {
 		return true
 	}
 
 	// only empty set is a subset of an empty set
-	if len(set) == 0 {
+	if len(s) == 0 {
 		return len(w) == 0
 	}
 
 	// find nesting separators
-	sep := strings.Index(set, "/")
-	wsep := strings.Index(w, "/")
+	sp := strings.Index(s, "/")
+	wp := strings.Index(w, "/")
 
 	// check if this is a nested path
-	if sep >= 0 {
+	if sp >= 0 {
 
 		// if set is nested then tested wildcard must be nested too
-		if wsep < 0 {
+		if wp < 0 {
 			return false
+		}
+
+		// Special case for /**/ mask that matches any number of levels
+		if s[:sp] == "**" &&
+			IsSubset(w[wp+1:], s) ||
+			IsSubset(w, s[sp+1:]) {
+			return true
 		}
 
 		// check that current level names are subsets
 		// and compare rest of the path to be subset also
-		return (IsSubset(w[:wsep], set[:sep]) &&
-			IsSubset(w[wsep+1:], set[sep+1:])) ||
-			// Special case for /**/ mask that matches any number of levels
-			(set[:sep] == "**" &&
-				(IsSubset(w[wsep+1:], set)) ||
-				(IsSubset(w, set[sep+1:])))
+		return (IsSubset(w[:wp], s[:sp]) &&
+			IsSubset(w[wp+1:], s[sp+1:]))
 	}
 
 	// subset can't have more levels than set
-	if wsep >= 0 {
+	if wp >= 0 {
 		return false
 	}
 
 	// we are comparing names on the same nesting level here
 	// so let's do symbol by symbol comparison
-	switch set[0] {
+	switch s[0] {
 	case '?':
 		// ? matches non empty character. '*' can't be a subset of '?'
 		if len(w) == 0 || w[0] == '*' {
 			return false
 		}
 		// any onther symbol matches '?', so let's skip to next
-		return IsSubset(w[1:], set[1:])
+		return IsSubset(w[1:], s[1:])
 	case '*':
 		// '*' matches 0 and any other number of symbols
 		// so checking 0 and recursively subset without first letter
-		return IsSubset(w, set[1:]) ||
-			(len(w) > 0 && IsSubset(w[1:], set))
+		return IsSubset(w, s[1:]) ||
+			(len(w) > 0 && IsSubset(w[1:], s))
 	default:
 		// making sure next symbol in w exists and it's the same as in set
-		if len(w) == 0 || w[0] != set[0] {
+		if len(w) == 0 || w[0] != s[0] {
 			return false
 		}
 	}
 
 	// recursively check rest of the set and w
-	return IsSubset(w[1:], set[1:])
+	return IsSubset(w[1:], s[1:])
 }

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -9,12 +9,13 @@ import (
 // It is an alias to the string type to provide extra methods of this package.
 type Wildcard string
 
+// IsSubset verifies if current wildcard is a subset of a given one.
+// Wildcard A is subset of B if any possible path that matches A also matches B.
 func (w Wildcard) IsSubset(set Wildcard) bool {
 	return IsSubset(string(w), string(set))
 }
 
-// IsSubset verifies if current wildcard is a subset of a given one.
-// Wildcard A is subset of B if any possible path that matches A also matches B.
+// IsSubset verifies if `w` wildcard is a subset of `set`.
 func IsSubset(w string, set string) bool {
 
 	// shortcut for identical sets
@@ -40,7 +41,7 @@ func IsSubset(w string, set string) bool {
 		}
 
 		// check that current level names are subsets
-		// and copare rest of the path to be subset also
+		// and compare rest of the path to be subset also
 		return (IsSubset(w[:wsep], set[:sep]) &&
 			IsSubset(w[wsep+1:], set[sep+1:])) ||
 			// Special case for /**/ mask that matches any number of levels
@@ -54,7 +55,7 @@ func IsSubset(w string, set string) bool {
 		return false
 	}
 
-	// we are comparing names on the same nesing level here
+	// we are comparing names on the same nesting level here
 	// so let's do symbol by symbol comparison
 	switch set[0] {
 	case '?':
@@ -74,7 +75,8 @@ func IsSubset(w string, set string) bool {
 		if len(w) == 0 || w[0] != set[0] {
 			return false
 		}
-		// recursively check rest of the set and w
-		return IsSubset(w[1:], set[1:])
 	}
+
+	// recursively check rest of the set and w
+	return IsSubset(w[1:], set[1:])
 }

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -74,5 +74,9 @@ func TestNested(t *testing.T) {
 	assert.False(t, Wildcard("a/b").IsSubset("**"))
 	assert.True(t, Wildcard("a/b/").IsSubset("**/"))
 	assert.True(t, Wildcard("a/b").IsSubset("a/**/b"))
+	assert.True(t, Wildcard("a/d").IsSubset("a/**/d"))
+	assert.True(t, Wildcard("a//d").IsSubset("a/**/d"))
+	assert.True(t, Wildcard("a/bc/d").IsSubset("a/**/d"))
 	assert.True(t, Wildcard("a/b/c/d").IsSubset("a/**/d"))
+	assert.True(t, Wildcard("a/b/c/e/f/d").IsSubset("a/**/d"))
 }


### PR DESCRIPTION
There are two versions of each function: string and Wildcard.

The same code:

```
wildmatch.Wildcard(w).IsSubsetOf(set)
wildmatch.IsSubsetOf(w, set)
wildmatch.Contains(set, w)
```
